### PR TITLE
fix(maze-runner-core): fix IL2026 warning at publishtrim

### DIFF
--- a/MazeRunner.Core/GameSerializables.cs
+++ b/MazeRunner.Core/GameSerializables.cs
@@ -2,7 +2,6 @@
 
 namespace Reveche.MazeRunner;
 
-[JsonSerializable(typeof(GameOptions))]
 public class GameOptions
 {
     public GameMode GameMode { get; set; } = GameMode.Classic;
@@ -11,13 +10,11 @@ public class GameOptions
     public MazeDifficulty MazeDifficulty { get; set; } = MazeDifficulty.Normal;
 }
 
-[JsonSerializable(typeof(ScoreList))]
 public class ScoreList
 {
     public List<ScoreEntry> Scores { get; set; } = new();
 }
 
-[JsonSerializable(typeof(ScoreEntry))]
 public class ScoreEntry
 {
     public string Name { get; }

--- a/MazeRunner.Core/OptionsManager.cs
+++ b/MazeRunner.Core/OptionsManager.cs
@@ -6,6 +6,14 @@ public static class OptionsManager
 {
     private const string OptionsFilePath = "MazeRunner.Options.json";
 
+    private static readonly JsonSerializerOptions SourceGenOptions = new()
+    {
+        TypeInfoResolver = GameOptionsJsonContext.Default,
+        WriteIndented = true
+    };
+
+    private static readonly GameOptionsJsonContext Context = new(SourceGenOptions);
+    
     public static GameOptions LoadOptions()
     {
         var defaultOptions = new GameOptions
@@ -18,15 +26,9 @@ public static class OptionsManager
 
         if (File.Exists(OptionsFilePath))
         {
-            var sourceGenOptions = new JsonSerializerOptions
-            {
-                TypeInfoResolver = GameOptionsJsonContext.Default
-            };
-
             var json = File.ReadAllText(OptionsFilePath);
             return JsonSerializer.Deserialize(
-                    json, typeof(GameOptions), sourceGenOptions)
-                as GameOptions ?? defaultOptions;
+                json, Context.GameOptions) ?? defaultOptions;
         }
 
         SaveOptions(defaultOptions);
@@ -35,13 +37,7 @@ public static class OptionsManager
 
     private static void SaveOptions(GameOptions options)
     {
-        var sourceGenOptions = new JsonSerializerOptions
-        {
-            TypeInfoResolver = GameOptionsJsonContext.Default,
-            WriteIndented = true
-        };
-
-        var json = JsonSerializer.Serialize(options, typeof(GameOptions), sourceGenOptions);
+        var json = JsonSerializer.Serialize(options, Context.GameOptions);
         File.WriteAllText(OptionsFilePath, json);
     }
 

--- a/MazeRunner.Core/ScoreManager.cs
+++ b/MazeRunner.Core/ScoreManager.cs
@@ -12,30 +12,27 @@ public class ScoreManager
         _scoreList = scoreList;
     }
 
+    private static readonly JsonSerializerOptions SourceGenOptions = new()
+    {
+        TypeInfoResolver = ScoreListJsonContext.Default,
+        WriteIndented = true
+    };
+
+    private static readonly ScoreListJsonContext Context = new(SourceGenOptions);
+
     public static ScoreList LoadScores()
     {
         var defaultScoreList = new ScoreList();
         if (!File.Exists(FilePath)) return defaultScoreList;
-        var sourceGenOptions = new JsonSerializerOptions
-        {
-            TypeInfoResolver = ScoreListJsonContext.Default
-        };
 
         var json = File.ReadAllText(FilePath);
         return JsonSerializer.Deserialize(
-                json, typeof(ScoreList), sourceGenOptions)
-            as ScoreList ?? defaultScoreList;
+            json, Context.ScoreList) ?? defaultScoreList;
     }
 
     public static void SaveScores(ScoreList scoreList)
     {
-        var sourceGenOptions = new JsonSerializerOptions
-        {
-            TypeInfoResolver = ScoreListJsonContext.Default,
-            WriteIndented = true
-        };
-
-        var json = JsonSerializer.Serialize(scoreList, typeof(ScoreList), sourceGenOptions);
+        var json = JsonSerializer.Serialize(scoreList, Context.ScoreList);
         File.WriteAllText(FilePath, json);
     }
 


### PR DESCRIPTION
Fix this code: Trim analysis warning IL2026: Using member 'System.Text.Json.JsonSerializer.Deserialize(String, Type, JsonSerializ
erOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON
serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a
 JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.