### PR TITLE
Scramble JSON data

### DIFF
--- a/MazeRunner.Console/Screens/OptionsScreen.cs
+++ b/MazeRunner.Console/Screens/OptionsScreen.cs
@@ -69,10 +69,12 @@ public class OptionsScreen
             {
                 case ConsoleKey.LeftArrow:
                     ChangeOptionValue(_options.ElementAt(selectedIndex).Key, _options, -1);
+                    OptionsManager.SaveCurrentOptions(_gameState, _gameOptions);
                     break;
 
                 case ConsoleKey.RightArrow:
                     ChangeOptionValue(_options.ElementAt(selectedIndex).Key, _options, 1);
+                    OptionsManager.SaveCurrentOptions(_gameState, _gameOptions);
                     break;
 
                 case ConsoleKey.UpArrow:
@@ -91,7 +93,7 @@ public class OptionsScreen
 
                     if (selectedIndex == _options.Count - 1)
                         MainScreen.StartMenu();
-                    return;
+                    break;
             }
         }
     }

--- a/MazeRunner.Core/GameSerializables.cs
+++ b/MazeRunner.Core/GameSerializables.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Reveche.MazeRunner;
 
@@ -31,3 +32,32 @@ internal partial class GameOptionsJsonContext : JsonSerializerContext;
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(ScoreList))]
 internal partial class ScoreListJsonContext : JsonSerializerContext;
+
+/// <summary>
+///     This is to just scramble the data to make it harder to read and edit.
+///     This is not meant to be secure.
+/// </summary>
+public static class JsonScrambler
+{
+    private const string ScramblerVersion1 = "v1";
+
+    public static string Encode(string json)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var base64 = Convert.ToBase64String(bytes);
+        var base64EncodedBytes = Encoding.UTF8.GetBytes(base64);
+        var hexString = Convert.ToHexString(base64EncodedBytes);
+
+        // Add version number to the beginning of the string, to allow for changes later.
+        return ScramblerVersion1 + hexString;
+    }
+
+    public static string Decode(string hexString)
+    {
+        var base64EncodedBytes = Convert.FromHexString(hexString[2..]);
+        var base64 = Encoding.UTF8.GetString(base64EncodedBytes);
+        var bytes = Convert.FromBase64String(base64);
+        var json = Encoding.UTF8.GetString(bytes);
+        return json;
+    }
+}

--- a/MazeRunner.Core/GameState.cs
+++ b/MazeRunner.Core/GameState.cs
@@ -12,7 +12,8 @@ public class GameState
     public GameState()
     {
         var options = OptionsManager.LoadOptions();
-
+        
+        GameMode = options.GameMode;
         IsSoundOn = options.IsSoundOn;
         IsUtf8 = options.IsUtf8;
         MazeDifficulty = options.MazeDifficulty;


### PR DESCRIPTION
As preparation for the campaign mode and for the integrity of the leaderboard, I implemented a scrambler to scramble the JSON data, so that prying eyes needs to dig more deeper to modify the data inside.

In the future, this will be done securely with cryptography and the works, but for now, as it is a simple project, it will suffice.